### PR TITLE
feat: add ip analysis tools

### DIFF
--- a/prisma/migrations/20250808032753_add_ip_tools/migration.sql
+++ b/prisma/migrations/20250808032753_add_ip_tools/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "portas" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "numero" INTEGER NOT NULL,
+    "protocolo" TEXT,
+    "servico" TEXT,
+    "estado" TEXT,
+    "ipId" INTEGER NOT NULL,
+    CONSTRAINT "portas_ipId_fkey" FOREIGN KEY ("ipId") REFERENCES "ips" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ip_infos" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "tipo" TEXT NOT NULL,
+    "chave" TEXT,
+    "valor" TEXT NOT NULL,
+    "ipId" INTEGER NOT NULL,
+    CONSTRAINT "ip_infos_ipId_fkey" FOREIGN KEY ("ipId") REFERENCES "ips" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,8 +66,35 @@ model Ip {
 
   dominios Dominio[]
   redes    Rede[]
+  portas   Porta[]
+  infos    IpInfo[]
 
   @@map("ips")
+}
+
+model Porta {
+  id       Int    @id @default(autoincrement())
+  numero   Int
+  protocolo String?
+  servico   String?
+  estado    String?
+
+  ipId Int
+  ip   Ip @relation(fields: [ipId], references: [id])
+
+  @@map("portas")
+}
+
+model IpInfo {
+  id    Int    @id @default(autoincrement())
+  tipo  String
+  chave String?
+  valor String
+
+  ipId Int
+  ip   Ip @relation(fields: [ipId], references: [id])
+
+  @@map("ip_infos")
 }
 
 model Command {

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,6 +1,7 @@
 import useDominios from "./dominios";
 import useFerramentas from "./ferramentas";
 import useIps from "./ips";
+import usePortas from "./portas";
 import useProjetos from "./projetos";
 import useQueue from "./queue";
 
@@ -9,12 +10,14 @@ const useApi = () => {
     const projetos = useProjetos();
     const ferramentas = useFerramentas();
     const ips = useIps();
+    const portas = usePortas();
     const queue = useQueue();
     return {
         projeto: { ...projetos },
         dominios: { ...dominios },
         ferramentas: { ...ferramentas },
         ips: { ...ips },
+        portas: { ...portas },
         queue: { ...queue },
     }
 }

--- a/src/api/portas.ts
+++ b/src/api/portas.ts
@@ -1,0 +1,20 @@
+"use client"
+import { PortResponse } from "@/types/PortResponse";
+import { useQuery } from "@tanstack/react-query";
+
+const usePortas = () => {
+  const getPorta = (idPorta?: number) => useQuery({
+    queryKey: ["get-porta", idPorta],
+    queryFn: async (): Promise<PortResponse> => {
+      const res = await fetch("/api/v1/portas/" + idPorta);
+      const data = await res.json();
+      return data;
+    },
+    enabled: !!idPorta
+  });
+
+  return { getPorta };
+};
+
+export default usePortas;
+

--- a/src/app/api/v1/ips/[id]/route.ts
+++ b/src/app/api/v1/ips/[id]/route.ts
@@ -11,6 +11,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         include: {
             dominios: true,
             redes: true,
+            portas: true,
+            infos: true,
         }
     });
     return NextResponse.json(ret);

--- a/src/app/api/v1/ips/route.ts
+++ b/src/app/api/v1/ips/route.ts
@@ -5,7 +5,12 @@ import { IpResponse } from "@/types/IpResponse";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(): ApiResponse<IpResponse[]> {
-    const ret = await prisma.ip.findMany();
+    const ret = await prisma.ip.findMany({
+        include: {
+            portas: true,
+            infos: true,
+        }
+    });
     return NextResponse.json(ret);
 }
 

--- a/src/app/api/v1/portas/[id]/route.ts
+++ b/src/app/api/v1/portas/[id]/route.ts
@@ -1,0 +1,15 @@
+import prisma from "@/database";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Id da porta é obrigatório" }, { status: 400 });
+  }
+  const ret = await prisma.porta.findFirst({
+    where: { id: Number(id) },
+    include: { ip: true }
+  });
+  return NextResponse.json(ret);
+}
+

--- a/src/app/api/v1/projetos/[id]/dominios/route.ts
+++ b/src/app/api/v1/projetos/[id]/dominios/route.ts
@@ -11,19 +11,19 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
             pai: null,
         },
         include: {
-            ips: true,
+            ips: { include: { portas: true } },
             subDominios: {
                 include: {
-                    ips: true,
+                    ips: { include: { portas: true } },
                     subDominios: {
                         include: {
-                            ips: true,
+                            ips: { include: { portas: true } },
                             subDominios: {
                                 include: {
-                                    ips: true,
+                                    ips: { include: { portas: true } },
                                     subDominios: {
                                         include: {
-                                            ips: true,
+                                            ips: { include: { portas: true } },
                                             subDominios: true,
                                         }
                                     }

--- a/src/components/Explorer/target/ElementoIp/index.tsx
+++ b/src/components/Explorer/target/ElementoIp/index.tsx
@@ -3,7 +3,7 @@ import StoreContext from "@/store";
 import { DominioResponse } from "@/types/DominioResponse"
 import { IpResponse } from "@/types/IpResponse";
 import { GlobalOutlined,  } from "@ant-design/icons";
-import { faHouseLaptop, faLaptop, faLaptopCode, faNetworkWired, faServer } from "@fortawesome/free-solid-svg-icons";
+import { faHouseLaptop, faLaptop, faLaptopCode, faNetworkWired, faServer, faPlug } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { TreeDataNode } from "antd";
 import React, { useContext } from "react";
@@ -18,6 +18,27 @@ const useElementoIp = () => {
     const checked = selecionado?.tipo === "ip" && selecionado?.id === ip.id;
     
     const filhos: TreeDataNode[] = [];
+
+    const portas = ip.portas ?? [];
+    if (portas.length) {
+      const filhosPortas: TreeDataNode[] = [];
+      for (let i = 0; i < portas.length; i++) {
+        const porta = portas[i];
+        filhosPortas.push({
+          key: `${ip.endereco}-${ip.id}-porta-${porta.id}`,
+          title: <div onClick={() => {
+            selecaoTarget?.set({ tipo: "port", id: porta.id })
+          }}><FontAwesomeIcon icon={faPlug} />{' '}{porta.numero}/{porta.protocolo}</div>,
+          className: "porta"
+        });
+      }
+      filhos.push({
+        key: `${ip.endereco}-${ip.id}-portas`,
+        title: <div><FontAwesomeIcon icon={faPlug} />{' '}Portas</div>,
+        children: filhosPortas,
+        className: "folder"
+      });
+    }
     
     return {
       key: `${ip.endereco}-${ip.id}}`,

--- a/src/components/Ferramentas/index.tsx
+++ b/src/components/Ferramentas/index.tsx
@@ -2,11 +2,13 @@
 import StoreContext from "@/store";
 import { useContext } from "react";
 import FerramentasDominio from "./target/FerramentasDominio";
+import FerramentasIp from "./target/FerramentasIp";
 
 const Ferramentas = () => {
     const { selecaoTarget } = useContext(StoreContext);
     return <>
     {selecaoTarget?.get()?.tipo === "domain" && <FerramentasDominio />}
+    {selecaoTarget?.get()?.tipo === "ip" && <FerramentasIp />}
     </>
 }
 

--- a/src/components/Ferramentas/target/FerramentasIp/index.tsx
+++ b/src/components/Ferramentas/target/FerramentasIp/index.tsx
@@ -1,0 +1,99 @@
+import { Card, Modal, notification } from "antd";
+import { StyledFerramentasIp } from "./styles";
+import useApi from "@/api";
+import { useContext, useState } from "react";
+import StoreContext from "@/store";
+
+const FerramentasIp = () => {
+    const api = useApi();
+    const { selecaoTarget, projeto } = useContext(StoreContext);
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const [commandToRun, setCommandToRun] = useState<{ command: string, args: any } | null>(null);
+
+    const showConfirmationModal = (command: string, args: any) => {
+        setCommandToRun({ command, args });
+        setIsModalVisible(true);
+    };
+
+    const handleOk = async () => {
+        if (commandToRun && selecaoTarget?.get()?.tipo === "ip") {
+            try {
+                const currentProject = projeto?.get();
+                if (!currentProject) {
+                    notification.error({
+                        message: 'Erro ao adicionar comando',
+                        description: 'Nenhum projeto selecionado.',
+                        placement: 'bottomRight',
+                    });
+                    setIsModalVisible(false);
+                    setCommandToRun(null);
+                    return;
+                }
+                await api.queue.addCommand(commandToRun.command, commandToRun.args, currentProject.id);
+                notification.success({
+                    message: 'Comando adicionado à fila',
+                    description: `O comando "${commandToRun.command}" foi adicionado à fila de execução.`,
+                    placement: 'bottomRight',
+                });
+            } catch (error) {
+                notification.error({
+                    message: 'Erro ao adicionar comando',
+                    description: 'Ocorreu um erro ao tentar adicionar o comando à fila.',
+                    placement: 'bottomRight',
+                });
+            }
+        }
+        setIsModalVisible(false);
+        setCommandToRun(null);
+    };
+
+    const handleCancel = () => {
+        setIsModalVisible(false);
+        setCommandToRun(null);
+    };
+
+    const getIpId = () => selecaoTarget?.get()?.id ?? 0;
+
+    return (
+        <StyledFerramentasIp>
+            <Card
+                title={"Nmap"}
+                onClick={() => showConfirmationModal('nmap', { idIp: getIpId().toString() })}
+            >
+                <Card.Meta description={"Varredura de portas e serviços."} />
+            </Card>
+            <Card
+                title={"Ping"}
+                onClick={() => showConfirmationModal('ping', { idIp: getIpId().toString() })}
+            >
+                <Card.Meta description={"Verificar latência e perda de pacotes."} />
+            </Card>
+            <Card
+                title={"Traceroute"}
+                onClick={() => showConfirmationModal('traceroute', { idIp: getIpId().toString() })}
+            >
+                <Card.Meta description={"Traçar rota até o IP."} />
+            </Card>
+            <Card
+                title={"Whois"}
+                onClick={() => showConfirmationModal('whois', { idIp: getIpId().toString() })}
+            >
+                <Card.Meta description={"Informações de registro e organização."} />
+            </Card>
+
+            <Modal
+                title="Confirmar Execução"
+                open={isModalVisible}
+                onOk={handleOk}
+                onCancel={handleCancel}
+                okText="Executar"
+                cancelText="Cancelar"
+            >
+                <p>Tem certeza que deseja executar o comando "{commandToRun?.command}"?</p>
+            </Modal>
+        </StyledFerramentasIp>
+    );
+};
+
+export default FerramentasIp;
+

--- a/src/components/Ferramentas/target/FerramentasIp/styles.ts
+++ b/src/components/Ferramentas/target/FerramentasIp/styles.ts
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+
+export const StyledFerramentasIp = styled.div`
+    .ant-card {
+        cursor: pointer;
+        border: 1px solid var(--border-color);
+        background-color: var(--panel-background);
+        margin-bottom: 8px;
+        border-radius: 6px;
+        transition: all 0.2s ease-in-out;
+
+        &:hover {
+            background-color: var(--hover-background);
+            border-color: var(--accent-color);
+        }
+
+        &:active {
+            transform: scale(0.98);
+            background-color: var(--hover-background);
+        }
+    }
+
+    .ant-card-head {
+        text-align: center;
+        min-height: 20px;
+        padding: 0 12px;
+        border-bottom: 1px solid var(--border-color);
+        font-size: 0.875rem;
+        font-weight: 600;
+    }
+
+    .ant-card-body {
+        padding: 8px 12px;
+        font-size: 0.8rem;
+    }
+
+    .ant-card-head *,
+    .ant-card-body * {
+        color: var(--foreground) !important;
+    }
+`
+

--- a/src/components/Visualizador/index.tsx
+++ b/src/components/Visualizador/index.tsx
@@ -6,6 +6,7 @@ import VisualizarIp from "./target/VisualizarIp";
 import VisualizarRede from "./target/VisualizarRede";
 import VisualizarUsuario from "./target/VisualizarUsuario";
 import VisualizarDatabase from "./target/VisualizarDatabase";
+import VisualizarPorta from "./target/VisualizarPorta";
 
 const Visualizador = () => {
     const { selecaoTarget } = useContext(StoreContext);
@@ -31,6 +32,8 @@ const Visualizador = () => {
             return <VisualizarUsuario />;
         case "database":
             return <VisualizarDatabase />;
+        case "port":
+            return <VisualizarPorta />;
         default:
             return (
                 <div style={{ textAlign: 'center', marginTop: '50px' }}>

--- a/src/components/Visualizador/target/VisualizarIp/index.tsx
+++ b/src/components/Visualizador/target/VisualizarIp/index.tsx
@@ -5,6 +5,8 @@ import { useContext } from "react";
 import styled from 'styled-components';
 import { DominioResponse } from "@/types/DominioResponse";
 import { RedeResponse } from "@/types/RedeResponse";
+import { PortResponse } from "@/types/PortResponse";
+import { IpInfoResponse } from "@/types/IpInfoResponse";
 
 // Reusing styled components from VisualizarDominio for consistency
 // In a real app, these would be in a shared styles file.
@@ -98,6 +100,58 @@ const VisualizarIp = () => {
                     </List>
                 ) : (
                     <p>Nenhuma rede associada encontrada.</p>
+                )}
+            </Card>
+
+            <Card>
+                <CardTitle>Portas</CardTitle>
+                {ip.portas && ip.portas.length > 0 ? (
+                    <List>
+                        {ip.portas.map((porta: PortResponse) => (
+                            <ListItem key={porta.id}>{porta.numero}/{porta.protocolo} - {porta.servico} ({porta.estado})</ListItem>
+                        ))}
+                    </List>
+                ) : (
+                    <p>Nenhuma porta encontrada.</p>
+                )}
+            </Card>
+
+            <Card>
+                <CardTitle>Ping</CardTitle>
+                {ip.infos && ip.infos.filter((i: IpInfoResponse) => i.tipo === 'ping').length > 0 ? (
+                    <List>
+                        {ip.infos.filter((i: IpInfoResponse) => i.tipo === 'ping').map((info: IpInfoResponse, idx: number) => (
+                            <ListItem key={idx}>{info.chave}: {info.valor}</ListItem>
+                        ))}
+                    </List>
+                ) : (
+                    <p>Nenhuma informação de ping.</p>
+                )}
+            </Card>
+
+            <Card>
+                <CardTitle>Traceroute</CardTitle>
+                {ip.infos && ip.infos.find((i: IpInfoResponse) => i.tipo === 'traceroute') ? (
+                    <List>
+                        {JSON.parse(ip.infos.find((i: IpInfoResponse) => i.tipo === 'traceroute')?.valor ?? '[]').map((hop: string, idx: number) => (
+                            <ListItem key={idx}>{hop}</ListItem>
+                        ))}
+                    </List>
+                ) : (
+                    <p>Nenhum dado de traceroute.</p>
+                )}
+            </Card>
+
+            <Card>
+                <CardTitle>Whois</CardTitle>
+                {ip.infos && ip.infos.filter((i: IpInfoResponse) => i.tipo === 'whois').length > 0 ? (
+                    <List>
+                        {ip.infos.filter((i: IpInfoResponse) => i.tipo === 'whois').map((info: IpInfoResponse, idx: number) => (
+                            <ListItem key={idx}>{info.chave}: {info.valor}</ListItem>
+                        ))}
+                    </List>
+                ) : (
+                    <p>Nenhuma informação de whois.</p>
                 )}
             </Card>
         </DashboardContainer>

--- a/src/components/Visualizador/target/VisualizarPorta/index.tsx
+++ b/src/components/Visualizador/target/VisualizarPorta/index.tsx
@@ -1,0 +1,66 @@
+"use client";
+import useApi from "@/api";
+import StoreContext from "@/store";
+import { useContext } from "react";
+import styled from 'styled-components';
+
+const DashboardContainer = styled.div`
+  padding: 2rem;
+  background-color: #f4f7f9;
+  font-family: 'Roboto', sans-serif;
+  color: #333;
+`;
+
+const Header = styled.div`
+  margin-bottom: 2rem;
+  h1 {
+    font-size: 2rem;
+    font-weight: 500;
+    color: #2c3e50;
+  }
+  p {
+    font-size: 1rem;
+    color: #7f8c8d;
+  }
+`;
+
+const List = styled.ul`
+  list-style: none;
+  padding: 0;
+`;
+
+const ListItem = styled.li`
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #ecf0f1;
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const VisualizarPorta = () => {
+    const { selecaoTarget } = useContext(StoreContext);
+    const api = useApi();
+    const idPorta = selecaoTarget?.get()?.id;
+    const { data: porta, isLoading, error } = api.portas.getPorta(idPorta);
+
+    if (isLoading) return <DashboardContainer><h2>Carregando...</h2></DashboardContainer>;
+    if (error) return <DashboardContainer><h2>Erro ao carregar dados da porta.</h2></DashboardContainer>;
+    if (!porta) return <DashboardContainer><h2>Nenhuma porta selecionada.</h2></DashboardContainer>;
+
+    return (
+        <DashboardContainer>
+            <Header>
+                <h1>{porta.numero}/{porta.protocolo}</h1>
+                <p>Informações da Porta</p>
+            </Header>
+            <List>
+                <ListItem>Serviço: {porta.servico}</ListItem>
+                <ListItem>Estado: {porta.estado}</ListItem>
+                {porta.ip && <ListItem>IP: {porta.ip.endereco}</ListItem>}
+            </List>
+        </DashboardContainer>
+    );
+}
+
+export default VisualizarPorta;
+

--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -1,9 +1,13 @@
 import * as dominio from "./functions/dominio"
 import * as ip from "./functions/ip"
+import * as porta from "./functions/porta"
+import * as ipinfo from "./functions/ipinfo"
 
 const Database = {
     ...dominio,
-    ...ip
+    ...ip,
+    ...porta,
+    ...ipinfo
 }
 
 export default Database;

--- a/src/database/functions/ipinfo.ts
+++ b/src/database/functions/ipinfo.ts
@@ -1,0 +1,25 @@
+import prisma from "..";
+
+export type TipoIpInfo = {
+  tipo: string;
+  chave?: string;
+  valor: string;
+};
+
+export const adicionarIpInfos = async (infos: TipoIpInfo[], ipId: number) => {
+  for (const info of infos) {
+    await prisma.ipInfo.create({
+      data: {
+        tipo: info.tipo,
+        chave: info.chave,
+        valor: info.valor,
+        ipId,
+      }
+    });
+  }
+};
+
+export const limparIpInfos = async (tipo: string, ipId: number) => {
+  await prisma.ipInfo.deleteMany({ where: { tipo, ipId } });
+};
+

--- a/src/database/functions/porta.ts
+++ b/src/database/functions/porta.ts
@@ -1,0 +1,42 @@
+import prisma from "..";
+
+export type TipoPorta = {
+  numero: number;
+  protocolo?: string;
+  servico?: string;
+  estado?: string;
+};
+
+export const adicionarPortas = async (portas: TipoPorta[], ipId: number) => {
+  const portasExistentes = await prisma.porta.findMany({
+    where: { ipId }
+  });
+
+  for (const p of portas) {
+    const existente = portasExistentes.find(pe => pe.numero === p.numero && pe.protocolo === p.protocolo);
+    if (existente) {
+      await prisma.porta.update({
+        where: { id: existente.id },
+        data: {
+          servico: p.servico,
+          estado: p.estado,
+        }
+      });
+    } else {
+      await prisma.porta.create({
+        data: {
+          numero: p.numero,
+          protocolo: p.protocolo,
+          servico: p.servico,
+          estado: p.estado,
+          ipId: ipId,
+        }
+      });
+    }
+  }
+};
+
+export const limparPortas = async (ipId: number) => {
+  await prisma.porta.deleteMany({ where: { ipId } });
+};
+

--- a/src/service/CommandProcessor.ts
+++ b/src/service/CommandProcessor.ts
@@ -5,12 +5,20 @@ import { iniciarEnumeracaoAmass } from '@/service/tools/domain/amass';
 // Let's assume the exports exist based on my previous analysis
 import { executarSubfinder } from '@/service/tools/domain/subfinder';
 import { executarNslookup } from '@/service/tools/domain/nslookup';
+import { executarNmap } from '@/service/tools/ip/nmap';
+import { executarPing } from '@/service/tools/ip/ping';
+import { executarTraceroute } from '@/service/tools/ip/traceroute';
+import { executarWhois } from '@/service/tools/ip/whois';
 
 // A map to associate command names with their service functions.
 const commandServiceMap: { [key: string]: (args: any) => Promise<any> } = {
     'amass': (args) => iniciarEnumeracaoAmass(args.idDominio),
     'subfinder': (args) => executarSubfinder(args.idDominio),
     'nslookup': (args) => executarNslookup(args.idDominio),
+    'nmap': (args) => executarNmap(args.idIp),
+    'ping': (args) => executarPing(args.idIp),
+    'traceroute': (args) => executarTraceroute(args.idIp),
+    'whois': (args) => executarWhois(args.idIp),
     // findomain is not implemented
 };
 

--- a/src/service/tools/ip/nmap/index.tsx
+++ b/src/service/tools/ip/nmap/index.tsx
@@ -1,0 +1,53 @@
+import path from 'node:path';
+import os from 'node:os';
+import prisma from '@/database';
+import { Terminal } from '@/service/terminal';
+import Database from '@/database/Database';
+import { TipoPorta } from '@/database/functions/porta';
+
+export const executarNmap = async (idIp: string) => {
+  const op = await prisma.ip.findFirst({
+    where: { id: Number(idIp) }
+  });
+  const ip = op?.endereco ?? '';
+
+  const nomeArquivoSaida = `nmap_${op?.projetoId}_${op?.id}_${ip}_${Date.now()}.txt`;
+  const caminhoSaida = path.join(os.tmpdir(), nomeArquivoSaida);
+
+  const comando = 'nmap';
+  const argumentos = ['-Pn', '-sV', ip];
+
+  const resultado = await Terminal(comando, argumentos, caminhoSaida);
+
+  const portas: TipoPorta[] = [];
+  const linhas = resultado.saidaComando?.split('\n') ?? [];
+  let parsing = false;
+  for (const linha of linhas) {
+    if (linha.startsWith('PORT')) {
+      parsing = true;
+      continue;
+    }
+    if (!parsing || linha.trim() === '') continue;
+    const partes = linha.trim().split(/\s+/);
+    if (partes.length >= 3) {
+      const [portaProto, estado, servico, ...resto] = partes;
+      const [numero, protocolo] = portaProto.split('/');
+      portas.push({
+        numero: Number(numero),
+        protocolo,
+        estado,
+        servico: [servico, ...resto].join(' ').trim() || undefined,
+      });
+    }
+  }
+
+  await Database.limparPortas(op?.id ?? 0);
+  await Database.adicionarPortas(portas, op?.id ?? 0);
+
+  return {
+    executedCommand: `${comando} ${argumentos.join(' ')}`,
+    rawOutput: resultado.saidaComando,
+    treatedResult: portas,
+  };
+};
+

--- a/src/service/tools/ip/ping/index.tsx
+++ b/src/service/tools/ip/ping/index.tsx
@@ -1,0 +1,45 @@
+import path from 'node:path';
+import os from 'node:os';
+import prisma from '@/database';
+import { Terminal } from '@/service/terminal';
+import Database from '@/database/Database';
+import { TipoIpInfo } from '@/database/functions/ipinfo';
+
+export const executarPing = async (idIp: string) => {
+  const op = await prisma.ip.findFirst({ where: { id: Number(idIp) } });
+  const ip = op?.endereco ?? '';
+
+  const nomeArquivoSaida = `ping_${op?.projetoId}_${op?.id}_${ip}_${Date.now()}.txt`;
+  const caminhoSaida = path.join(os.tmpdir(), nomeArquivoSaida);
+
+  const comando = 'ping';
+  const argumentos = ['-c', '4', ip];
+
+  const resultado = await Terminal(comando, argumentos, caminhoSaida);
+
+  const infos: TipoIpInfo[] = [];
+  const saida = resultado.saidaComando || '';
+
+  const matchStats = saida.match(/(\d+) packets transmitted, (\d+) received, .*?, (\d+)% packet loss/);
+  if (matchStats) {
+    infos.push({ tipo: 'ping', chave: 'transmitted', valor: matchStats[1] });
+    infos.push({ tipo: 'ping', chave: 'received', valor: matchStats[2] });
+    infos.push({ tipo: 'ping', chave: 'packet_loss', valor: matchStats[3] });
+  }
+  const matchRtt = saida.match(/rtt min\/avg\/max\/\w+ = ([^\/]+)\/([^\/]+)\/([^\/]+)/);
+  if (matchRtt) {
+    infos.push({ tipo: 'ping', chave: 'rtt_min', valor: matchRtt[1] });
+    infos.push({ tipo: 'ping', chave: 'rtt_avg', valor: matchRtt[2] });
+    infos.push({ tipo: 'ping', chave: 'rtt_max', valor: matchRtt[3] });
+  }
+
+  await Database.limparIpInfos('ping', op?.id ?? 0);
+  await Database.adicionarIpInfos(infos, op?.id ?? 0);
+
+  return {
+    executedCommand: `${comando} ${argumentos.join(' ')}`,
+    rawOutput: resultado.saidaComando,
+    treatedResult: infos,
+  };
+};
+

--- a/src/service/tools/ip/traceroute/index.tsx
+++ b/src/service/tools/ip/traceroute/index.tsx
@@ -1,0 +1,42 @@
+import path from 'node:path';
+import os from 'node:os';
+import prisma from '@/database';
+import { Terminal } from '@/service/terminal';
+import Database from '@/database/Database';
+import { TipoIpInfo } from '@/database/functions/ipinfo';
+
+export const executarTraceroute = async (idIp: string) => {
+  const op = await prisma.ip.findFirst({ where: { id: Number(idIp) } });
+  const ip = op?.endereco ?? '';
+
+  const nomeArquivoSaida = `traceroute_${op?.projetoId}_${op?.id}_${ip}_${Date.now()}.txt`;
+  const caminhoSaida = path.join(os.tmpdir(), nomeArquivoSaida);
+
+  const comando = 'traceroute';
+  const argumentos = ['-n', ip];
+
+  const resultado = await Terminal(comando, argumentos, caminhoSaida);
+
+  const hops: string[] = [];
+  const linhas = resultado.saidaComando?.split('\n') ?? [];
+  for (const linha of linhas) {
+    const match = linha.trim().match(/^\s*\d+\s+([0-9.]+)/);
+    if (match) {
+      hops.push(match[1]);
+    }
+  }
+
+  const infos: TipoIpInfo[] = [
+    { tipo: 'traceroute', chave: 'hops', valor: JSON.stringify(hops) }
+  ];
+
+  await Database.limparIpInfos('traceroute', op?.id ?? 0);
+  await Database.adicionarIpInfos(infos, op?.id ?? 0);
+
+  return {
+    executedCommand: `${comando} ${argumentos.join(' ')}`,
+    rawOutput: resultado.saidaComando,
+    treatedResult: hops,
+  };
+};
+

--- a/src/service/tools/ip/whois/index.tsx
+++ b/src/service/tools/ip/whois/index.tsx
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import os from 'node:os';
+import prisma from '@/database';
+import { Terminal } from '@/service/terminal';
+import Database from '@/database/Database';
+import { TipoIpInfo } from '@/database/functions/ipinfo';
+
+export const executarWhois = async (idIp: string) => {
+  const op = await prisma.ip.findFirst({ where: { id: Number(idIp) } });
+  const ip = op?.endereco ?? '';
+
+  const nomeArquivoSaida = `whois_${op?.projetoId}_${op?.id}_${ip}_${Date.now()}.txt`;
+  const caminhoSaida = path.join(os.tmpdir(), nomeArquivoSaida);
+
+  const comando = 'whois';
+  const argumentos = [ip];
+
+  const resultado = await Terminal(comando, argumentos, caminhoSaida);
+
+  const infos: TipoIpInfo[] = [];
+  const linhas = resultado.saidaComando?.split('\n') ?? [];
+  const chavesDesejadas = ['OrgName', 'Organization', 'Country', 'NetName', 'OrgId'];
+  for (const linha of linhas) {
+    const tmp = linha.split(':');
+    if (tmp.length >= 2) {
+      const chave = tmp[0].trim();
+      const valor = tmp.slice(1).join(':').trim();
+      if (chavesDesejadas.includes(chave)) {
+        infos.push({ tipo: 'whois', chave, valor });
+      }
+    }
+  }
+
+  await Database.limparIpInfos('whois', op?.id ?? 0);
+  await Database.adicionarIpInfos(infos, op?.id ?? 0);
+
+  return {
+    executedCommand: `${comando} ${argumentos.join(' ')}`,
+    rawOutput: resultado.saidaComando,
+    treatedResult: infos,
+  };
+};
+

--- a/src/types/IpInfoResponse.ts
+++ b/src/types/IpInfoResponse.ts
@@ -1,0 +1,8 @@
+export type IpInfoResponse = {
+    id?: number;
+    tipo?: string;
+    chave?: string | null;
+    valor?: string;
+    ipId?: number;
+}
+

--- a/src/types/IpResponse.ts
+++ b/src/types/IpResponse.ts
@@ -1,5 +1,14 @@
+import { PortResponse } from "./PortResponse";
+import { IpInfoResponse } from "./IpInfoResponse";
+import { DominioResponse } from "./DominioResponse";
+import { RedeResponse } from "./RedeResponse";
+
 export type IpResponse = {
     id?: number;
     endereco?: string;
     projetoId?: number;
+    dominios?: DominioResponse[];
+    redes?: RedeResponse[];
+    portas?: PortResponse[];
+    infos?: IpInfoResponse[];
 }

--- a/src/types/PortResponse.ts
+++ b/src/types/PortResponse.ts
@@ -1,0 +1,10 @@
+export type PortResponse = {
+    id?: number;
+    numero?: number;
+    protocolo?: string | null;
+    servico?: string | null;
+    estado?: string | null;
+    ipId?: number;
+    ip?: { endereco?: string };
+}
+

--- a/src/types/TargetType.ts
+++ b/src/types/TargetType.ts
@@ -1,6 +1,7 @@
 export type TargetType = 
     | "domain" 
     | "network"
-    | "user" 
+    | "user"
     | "database"
-    | "ip";
+    | "ip"
+    | "port";


### PR DESCRIPTION
## Summary
- support storing IP scan results (ports and metadata)
- add queueable IP tools like nmap, ping, traceroute and whois
- show port targets and IP details in explorer and visualizer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: React Hook "useQuery" is called in function "getDominios" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".)

------
https://chatgpt.com/codex/tasks/task_e_68956d6123f883259c1c8b87180d7293