### PR TITLE
feat: add IP port scanning tool

### DIFF
--- a/prisma/migrations/20250808032919_add_porta_model/migration.sql
+++ b/prisma/migrations/20250808032919_add_porta_model/migration.sql
@@ -1,0 +1,10 @@
+-- CreateTable
+CREATE TABLE "portas" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "numero" INTEGER NOT NULL,
+    "protocolo" TEXT NOT NULL,
+    "estado" TEXT,
+    "servico" TEXT,
+    "ipId" INTEGER NOT NULL,
+    CONSTRAINT "portas_ipId_fkey" FOREIGN KEY ("ipId") REFERENCES "ips" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,8 +66,22 @@ model Ip {
 
   dominios Dominio[]
   redes    Rede[]
+  portas   Porta[]
 
   @@map("ips")
+}
+
+model Porta {
+  id        Int    @id @default(autoincrement())
+  numero    Int
+  protocolo String
+  estado    String?
+  servico   String?
+
+  ipId Int
+  ip   Ip @relation(fields: [ipId], references: [id])
+
+  @@map("portas")
 }
 
 model Command {

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -1,6 +1,7 @@
 import useDominios from "./dominios";
 import useFerramentas from "./ferramentas";
 import useIps from "./ips";
+import usePortas from "./portas";
 import useProjetos from "./projetos";
 import useQueue from "./queue";
 
@@ -9,12 +10,14 @@ const useApi = () => {
     const projetos = useProjetos();
     const ferramentas = useFerramentas();
     const ips = useIps();
+    const portas = usePortas();
     const queue = useQueue();
     return {
         projeto: { ...projetos },
         dominios: { ...dominios },
         ferramentas: { ...ferramentas },
         ips: { ...ips },
+        portas: { ...portas },
         queue: { ...queue },
     }
 }

--- a/src/api/portas.ts
+++ b/src/api/portas.ts
@@ -1,0 +1,19 @@
+"use client"
+import { PortaResponse } from "@/types/PortaResponse";
+import { useQuery } from "@tanstack/react-query";
+
+const usePortas = () => {
+  const getPorta = (idPorta?: number) => useQuery({
+    queryKey: ["get-porta", idPorta],
+    queryFn: async (): Promise<PortaResponse> => {
+      const res = await fetch("/api/v1/portas/" + idPorta);
+      const data = await res.json();
+      return data;
+    },
+    enabled: !!idPorta,
+  });
+
+  return { getPorta };
+};
+
+export default usePortas;

--- a/src/app/api/v1/ips/[id]/route.ts
+++ b/src/app/api/v1/ips/[id]/route.ts
@@ -11,6 +11,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         include: {
             dominios: true,
             redes: true,
+            portas: true,
         }
     });
     return NextResponse.json(ret);

--- a/src/app/api/v1/portas/[id]/route.ts
+++ b/src/app/api/v1/portas/[id]/route.ts
@@ -1,0 +1,15 @@
+import prisma from "@/database";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Id da porta é obrigatório" }, { status: 400 });
+  }
+
+  const ret = await prisma.porta.findFirst({
+    where: { id: Number(id) },
+    include: { ip: true },
+  });
+  return NextResponse.json(ret);
+}

--- a/src/app/api/v1/projetos/[id]/dominios/route.ts
+++ b/src/app/api/v1/projetos/[id]/dominios/route.ts
@@ -11,19 +11,19 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
             pai: null,
         },
         include: {
-            ips: true,
+            ips: { include: { portas: true } },
             subDominios: {
                 include: {
-                    ips: true,
+                    ips: { include: { portas: true } },
                     subDominios: {
                         include: {
-                            ips: true,
+                            ips: { include: { portas: true } },
                             subDominios: {
                                 include: {
-                                    ips: true,
+                                    ips: { include: { portas: true } },
                                     subDominios: {
                                         include: {
-                                            ips: true,
+                                            ips: { include: { portas: true } },
                                             subDominios: true,
                                         }
                                     }

--- a/src/components/Explorer/target/ElementoIp/index.tsx
+++ b/src/components/Explorer/target/ElementoIp/index.tsx
@@ -1,30 +1,44 @@
-import useApi from "@/api";
 import StoreContext from "@/store";
-import { DominioResponse } from "@/types/DominioResponse"
 import { IpResponse } from "@/types/IpResponse";
-import { GlobalOutlined,  } from "@ant-design/icons";
-import { faHouseLaptop, faLaptop, faLaptopCode, faNetworkWired, faServer } from "@fortawesome/free-solid-svg-icons";
+import { PortaResponse } from "@/types/PortaResponse";
+import { faPlug, faServer } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { TreeDataNode } from "antd";
 import React, { useContext } from "react";
 
 const useElementoIp = () => {
   const { selecaoTarget } = useContext(StoreContext);
-  const api = useApi();
 
-  const selecionado = selecaoTarget?.get()
+  const selecionado = selecaoTarget?.get();
 
   const getIp = async (ip: IpResponse): Promise<TreeDataNode> => {
     const checked = selecionado?.tipo === "ip" && selecionado?.id === ip.id;
-    
+
     const filhos: TreeDataNode[] = [];
-    
+
+    const portas = ip.portas ?? [];
+    if (portas.length) {
+      const filhosPortas: TreeDataNode[] = portas.map((porta: PortaResponse) => ({
+        key: `${ip.endereco}-${ip.id}-porta-${porta.id}`,
+        title: <div onClick={() => selecaoTarget?.set({ tipo: "port", id: porta.id })}>
+          <FontAwesomeIcon icon={faPlug} />{' '}{porta.numero}/{porta.protocolo}{porta.servico ? ` - ${porta.servico}` : ''}
+        </div>,
+        className: "porta " + (selecionado?.tipo === 'port' && selecionado?.id === porta.id ? 'checked ' : ''),
+      }));
+      filhos.push({
+        key: `${ip.endereco}-${ip.id}-portas`,
+        title: <div><FontAwesomeIcon icon={faPlug} />{' '}Portas</div>,
+        className: "folder",
+        children: filhosPortas
+      });
+    }
+
     return {
       key: `${ip.endereco}-${ip.id}}`,
       title: <div onClick={() => {
         selecaoTarget?.set({ tipo: "ip", id: ip.id })
       }}>
-        <FontAwesomeIcon icon={faServer}  />{' '}
+        <FontAwesomeIcon icon={faServer} />{' '}
         {ip.endereco}
       </div>,
       className: "ip " + (checked ? "checked " : ""),

--- a/src/components/Ferramentas/index.tsx
+++ b/src/components/Ferramentas/index.tsx
@@ -2,11 +2,13 @@
 import StoreContext from "@/store";
 import { useContext } from "react";
 import FerramentasDominio from "./target/FerramentasDominio";
+import FerramentasIp from "./target/FerramentasIp";
 
 const Ferramentas = () => {
     const { selecaoTarget } = useContext(StoreContext);
     return <>
     {selecaoTarget?.get()?.tipo === "domain" && <FerramentasDominio />}
+    {selecaoTarget?.get()?.tipo === "ip" && <FerramentasIp />}
     </>
 }
 

--- a/src/components/Ferramentas/target/FerramentasIp/index.tsx
+++ b/src/components/Ferramentas/target/FerramentasIp/index.tsx
@@ -1,0 +1,80 @@
+import { Card, Modal, notification } from "antd";
+import { StyledFerramentasIp } from "./styles";
+import useApi from "@/api";
+import { useContext, useState } from "react";
+import StoreContext from "@/store";
+
+const FerramentasIp = () => {
+    const api = useApi();
+    const { selecaoTarget, projeto } = useContext(StoreContext);
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const [commandToRun, setCommandToRun] = useState<{ command: string, args: any } | null>(null);
+
+    const showConfirmationModal = (command: string, args: any) => {
+        setCommandToRun({ command, args });
+        setIsModalVisible(true);
+    };
+
+    const handleOk = async () => {
+        if (commandToRun && selecaoTarget?.get()?.tipo === "ip") {
+            try {
+                const currentProject = projeto?.get();
+                if (!currentProject) {
+                    notification.error({
+                        message: 'Erro ao adicionar comando',
+                        description: 'Nenhum projeto selecionado.',
+                        placement: 'bottomRight',
+                    });
+                    setIsModalVisible(false);
+                    setCommandToRun(null);
+                    return;
+                }
+                await api.queue.addCommand(commandToRun.command, commandToRun.args, currentProject.id);
+                notification.success({
+                    message: 'Comando adicionado à fila',
+                    description: `O comando "${commandToRun.command}" foi adicionado à fila de execução.`,
+                    placement: 'bottomRight',
+                });
+            } catch (error) {
+                notification.error({
+                    message: 'Erro ao adicionar comando',
+                    description: 'Ocorreu um erro ao tentar adicionar o comando à fila.',
+                    placement: 'bottomRight',
+                });
+            }
+        }
+        setIsModalVisible(false);
+        setCommandToRun(null);
+    };
+
+    const handleCancel = () => {
+        setIsModalVisible(false);
+        setCommandToRun(null);
+    };
+
+    const getIpId = () => selecaoTarget?.get()?.id ?? 0;
+
+    return (
+        <StyledFerramentasIp>
+            <Card
+                title={"Nmap -Pn"}
+                onClick={() => showConfirmationModal('nmap', { idIp: getIpId().toString() })}
+            >
+                <Card.Meta description={"Varredura de portas com Nmap."} />
+            </Card>
+
+            <Modal
+                title="Confirmar Execução"
+                open={isModalVisible}
+                onOk={handleOk}
+                onCancel={handleCancel}
+                okText="Executar"
+                cancelText="Cancelar"
+            >
+                <p>Tem certeza que deseja executar o comando "{commandToRun?.command}"?</p>
+            </Modal>
+        </StyledFerramentasIp>
+    );
+};
+
+export default FerramentasIp;

--- a/src/components/Ferramentas/target/FerramentasIp/styles.ts
+++ b/src/components/Ferramentas/target/FerramentasIp/styles.ts
@@ -1,0 +1,41 @@
+import styled from "styled-components";
+
+export const StyledFerramentasIp = styled.div`
+    .ant-card {
+        cursor: pointer;
+        border: 1px solid var(--border-color);
+        background-color: var(--panel-background);
+        margin-bottom: 8px;
+        border-radius: 6px;
+        transition: all 0.2s ease-in-out;
+
+        &:hover {
+            background-color: var(--hover-background);
+            border-color: var(--accent-color);
+        }
+
+        &:active {
+            transform: scale(0.98);
+            background-color: var(--hover-background);
+        }
+    }
+
+    .ant-card-head {
+        text-align: center;
+        min-height: 20px;
+        padding: 0 12px;
+        border-bottom: 1px solid var(--border-color);
+        font-size: 0.875rem;
+        font-weight: 600;
+    }
+
+    .ant-card-body {
+        padding: 8px 12px;
+        font-size: 0.8rem;
+    }
+
+    .ant-card-head *,
+    .ant-card-body * {
+        color: var(--foreground) !important;
+    }
+`;

--- a/src/components/Visualizador/index.tsx
+++ b/src/components/Visualizador/index.tsx
@@ -3,6 +3,7 @@ import StoreContext from "@/store"
 import { useContext } from "react"
 import VisualizarDominio from "./target/VisualizarDominio";
 import VisualizarIp from "./target/VisualizarIp";
+import VisualizarPorta from "./target/VisualizarPorta";
 import VisualizarRede from "./target/VisualizarRede";
 import VisualizarUsuario from "./target/VisualizarUsuario";
 import VisualizarDatabase from "./target/VisualizarDatabase";
@@ -25,6 +26,8 @@ const Visualizador = () => {
             return <VisualizarDominio />;
         case "ip":
             return <VisualizarIp />;
+        case "port":
+            return <VisualizarPorta />;
         case "network":
             return <VisualizarRede />;
         case "user":

--- a/src/components/Visualizador/target/VisualizarIp/index.tsx
+++ b/src/components/Visualizador/target/VisualizarIp/index.tsx
@@ -5,6 +5,7 @@ import { useContext } from "react";
 import styled from 'styled-components';
 import { DominioResponse } from "@/types/DominioResponse";
 import { RedeResponse } from "@/types/RedeResponse";
+import { PortaResponse } from "@/types/PortaResponse";
 
 // Reusing styled components from VisualizarDominio for consistency
 // In a real app, these would be in a shared styles file.
@@ -98,6 +99,19 @@ const VisualizarIp = () => {
                     </List>
                 ) : (
                     <p>Nenhuma rede associada encontrada.</p>
+                )}
+            </Card>
+
+            <Card>
+                <CardTitle>Portas</CardTitle>
+                {ip.portas && ip.portas.length > 0 ? (
+                    <List>
+                        {ip.portas.map((porta: PortaResponse) => (
+                            <ListItem key={porta.id}>{porta.numero}/{porta.protocolo} - {porta.servico} ({porta.estado})</ListItem>
+                        ))}
+                    </List>
+                ) : (
+                    <p>Nenhuma porta registrada.</p>
                 )}
             </Card>
         </DashboardContainer>

--- a/src/components/Visualizador/target/VisualizarPorta/index.tsx
+++ b/src/components/Visualizador/target/VisualizarPorta/index.tsx
@@ -1,0 +1,54 @@
+"use client";
+import useApi from "@/api";
+import StoreContext from "@/store";
+import { useContext } from "react";
+import styled from 'styled-components';
+
+const Container = styled.div`
+  padding: 2rem;
+  background-color: #f4f7f9;
+  font-family: 'Roboto', sans-serif;
+  color: #333;
+`;
+
+const Card = styled.div`
+  background-color: #ffffff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+  margin-bottom: 1.5rem;
+`;
+
+const CardTitle = styled.h2`
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+  color: #34495e;
+  border-bottom: 1px solid #ecf0f1;
+  padding-bottom: 0.5rem;
+`;
+
+const VisualizarPorta = () => {
+    const { selecaoTarget } = useContext(StoreContext);
+    const api = useApi();
+    const idPorta = selecaoTarget?.get()?.id;
+    const { data: porta, isLoading, error } = api.portas.getPorta(idPorta);
+
+    if (isLoading) return <Container><h2>Carregando...</h2></Container>;
+    if (error) return <Container><h2>Erro ao carregar dados da porta.</h2></Container>;
+    if (!porta) return <Container><h2>Nenhuma porta selecionada.</h2></Container>;
+
+    return (
+        <Container>
+            <Card>
+                <CardTitle>Detalhes da Porta</CardTitle>
+                <p><strong>Porta:</strong> {porta.numero}/{porta.protocolo}</p>
+                <p><strong>Serviço:</strong> {porta.servico}</p>
+                <p><strong>Estado:</strong> {porta.estado}</p>
+                {porta.ip && <p><strong>IP:</strong> {porta.ip.endereco}</p>}
+            </Card>
+        </Container>
+    );
+}
+
+export default VisualizarPorta;

--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -1,9 +1,11 @@
 import * as dominio from "./functions/dominio"
 import * as ip from "./functions/ip"
+import * as porta from "./functions/porta"
 
 const Database = {
     ...dominio,
-    ...ip
+    ...ip,
+    ...porta
 }
 
 export default Database;

--- a/src/database/functions/porta.ts
+++ b/src/database/functions/porta.ts
@@ -1,0 +1,38 @@
+import prisma from "..";
+
+export type TipoPorta = {
+  numero: number;
+  protocolo: string;
+  estado: string;
+  servico?: string;
+};
+
+export const adicionarPortas = async (portas: TipoPorta[], ipId: number) => {
+  const ip = await prisma.ip.findFirst({
+    where: { id: ipId },
+    include: { portas: true },
+  });
+  if (!ip) return;
+
+  for (const porta of portas) {
+    const existente = ip.portas.find(
+      (p) => p.numero === porta.numero && p.protocolo === porta.protocolo
+    );
+    if (!existente) {
+      await prisma.porta.create({
+        data: {
+          numero: porta.numero,
+          protocolo: porta.protocolo,
+          estado: porta.estado,
+          servico: porta.servico,
+          ipId,
+        },
+      });
+    } else {
+      await prisma.porta.update({
+        where: { id: existente.id },
+        data: { estado: porta.estado, servico: porta.servico },
+      });
+    }
+  }
+};

--- a/src/service/CommandProcessor.ts
+++ b/src/service/CommandProcessor.ts
@@ -5,12 +5,14 @@ import { iniciarEnumeracaoAmass } from '@/service/tools/domain/amass';
 // Let's assume the exports exist based on my previous analysis
 import { executarSubfinder } from '@/service/tools/domain/subfinder';
 import { executarNslookup } from '@/service/tools/domain/nslookup';
+import { executarNmap } from '@/service/tools/ip/nmap';
 
 // A map to associate command names with their service functions.
 const commandServiceMap: { [key: string]: (args: any) => Promise<any> } = {
     'amass': (args) => iniciarEnumeracaoAmass(args.idDominio),
     'subfinder': (args) => executarSubfinder(args.idDominio),
     'nslookup': (args) => executarNslookup(args.idDominio),
+    'nmap': (args) => executarNmap(args.idIp),
     // findomain is not implemented
 };
 

--- a/src/service/tools/ip/nmap/index.tsx
+++ b/src/service/tools/ip/nmap/index.tsx
@@ -1,0 +1,43 @@
+import prisma from '@/database';
+import Database from '@/database/Database';
+import { Terminal } from '@/service/terminal';
+import { TipoPorta } from '@/database/functions/porta';
+import os from 'os';
+import path from 'path';
+
+export const executarNmap = async (idIp: string) => {
+  const op = await prisma.ip.findFirst({ where: { id: Number(idIp) } });
+  const ip = op?.endereco ?? '';
+  if (!ip) {
+    throw new Error('IP inválido fornecido.');
+  }
+
+  const nomeArquivoSaida = `nmap_resultado_${op?.projetoId}_${op?.id}_${ip}_${Date.now()}.txt`;
+  const caminhoSaida = path.join(os.tmpdir(), nomeArquivoSaida);
+
+  const comando = 'nmap';
+  const argumentos = ['-Pn', ip, '2>&1'];
+
+  const resultado = await Terminal(comando, argumentos, caminhoSaida);
+
+  const portas: TipoPorta[] = [];
+  resultado.saidaComando?.split('\n').forEach(linha => {
+    const match = linha.match(/^(\d+)\/(tcp|udp)\s+(\w+)\s+([\w\-\.?]+)/);
+    if (match) {
+      portas.push({
+        numero: Number(match[1]),
+        protocolo: match[2],
+        estado: match[3],
+        servico: match[4]
+      });
+    }
+  });
+
+  await Database.adicionarPortas(portas, op?.id ?? 0);
+
+  return {
+    executedCommand: `${comando} ${argumentos.join(' ')}`,
+    rawOutput: resultado.saidaComando,
+    treatedResult: portas,
+  };
+};

--- a/src/types/IpResponse.ts
+++ b/src/types/IpResponse.ts
@@ -1,5 +1,12 @@
+import { DominioResponse } from "./DominioResponse";
+import { RedeResponse } from "./RedeResponse";
+import { PortaResponse } from "./PortaResponse";
+
 export type IpResponse = {
     id?: number;
     endereco?: string;
     projetoId?: number;
+    dominios?: DominioResponse[];
+    redes?: RedeResponse[];
+    portas?: PortaResponse[];
 }

--- a/src/types/PortaResponse.ts
+++ b/src/types/PortaResponse.ts
@@ -1,0 +1,11 @@
+import { IpResponse } from "./IpResponse";
+
+export type PortaResponse = {
+    id?: number;
+    numero?: number;
+    protocolo?: string;
+    estado?: string | null;
+    servico?: string | null;
+    ipId?: number;
+    ip?: IpResponse;
+};

--- a/src/types/TargetType.ts
+++ b/src/types/TargetType.ts
@@ -1,6 +1,7 @@
-export type TargetType = 
-    | "domain" 
+export type TargetType =
+    | "domain"
     | "network"
-    | "user" 
+    | "user"
     | "database"
-    | "ip";
+    | "ip"
+    | "port";


### PR DESCRIPTION
## Summary
- add database model for ports linked to IPs
- implement nmap scanning service and command mapping
- expose ports through API and UI with new viewer and tools

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: React Hook "useQuery" is called in function ...)


------
https://chatgpt.com/codex/tasks/task_e_68956d6123f883259c1c8b87180d7293