### PR TITLE
Adiciona selecao de layout com seis temas

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import React from "react";
+import React, { useContext } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import StoreContext, { StoreProvider } from "@/store";
 import { ThemeProvider } from "styled-components";
-import { theme, GlobalStyles } from "@/theme";
+import { temas, GlobalStyles } from "@/theme";
 
 function makeQueryClient() {
   return new QueryClient({
@@ -28,16 +28,25 @@ function getQueryClient() {
   }
 }
 
+function TemaProvider({ children }: { children: React.ReactNode }) {
+  const { tema } = useContext(StoreContext);
+  const temaAtual = temas[tema?.get() ?? "sombrio"];
+
+  return (
+    <ThemeProvider theme={temaAtual}>
+      <GlobalStyles />
+      {children}
+    </ThemeProvider>
+  );
+}
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>
       <StoreProvider>
-        <ThemeProvider theme={theme}>
-          <GlobalStyles />
-          {children}
-        </ThemeProvider>
+        <TemaProvider>{children}</TemaProvider>
       </StoreProvider>
     </QueryClientProvider>
   );

--- a/src/components/SelecaoTema/index.tsx
+++ b/src/components/SelecaoTema/index.tsx
@@ -1,0 +1,22 @@
+import { useContext } from "react";
+import StoreContext from "@/store";
+import { TemaType } from "@/types/TemaType";
+import { StyledSelect } from "./styles";
+
+const SelecaoTema = () => {
+    const { tema } = useContext(StoreContext);
+    const atual = tema?.get() ?? "sombrio";
+
+    return (
+        <StyledSelect value={atual} onChange={e => tema?.set(e.target.value as TemaType)}>
+            <option value="classico">Clássico</option>
+            <option value="hacker">Hacker</option>
+            <option value="fofo">Fofinho</option>
+            <option value="elegante">Elegante</option>
+            <option value="sombrio">Dark</option>
+            <option value="clean">Clean</option>
+        </StyledSelect>
+    );
+};
+
+export default SelecaoTema;

--- a/src/components/SelecaoTema/styles.ts
+++ b/src/components/SelecaoTema/styles.ts
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+export const StyledSelect = styled.select`
+    background-color: ${({ theme }) => theme.colors.panelBackground};
+    color: ${({ theme }) => theme.colors.foreground};
+    border: 1px solid ${({ theme }) => theme.colors.borderColor};
+    padding: 0.25rem;
+`;

--- a/src/layout/Topo/index.tsx
+++ b/src/layout/Topo/index.tsx
@@ -4,6 +4,7 @@ import SelecaoProjetos from "@/components/SelecaoProjetos";
 import { useContext } from "react";
 import StoreContext from "@/store";
 import styled from "styled-components";
+import SelecaoTema from "@/components/SelecaoTema";
 
 const StyledProjectTitle = styled.div`
     font-size: 1rem;
@@ -16,6 +17,11 @@ const StyledProjectTitle = styled.div`
     }
 `
 
+const ContainerDireita = styled.div`
+    display: flex;
+    gap: 1rem;
+`
+
 const Topo = () => {
     const { projeto } = useContext(StoreContext);
 
@@ -24,7 +30,7 @@ const Topo = () => {
             {!!projeto?.get()?.id && <span><b>Projeto:</b> {projeto?.get()?.nome}</span>}
             {!projeto?.get()?.id && <span>Selecione um projeto</span>}
         </StyledProjectTitle>
-        <div><SelecaoProjetos /></div>
+        <ContainerDireita><SelecaoProjetos /><SelecaoTema /></ContainerDireita>
     </StyledTopo>
 }
 

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -5,6 +5,7 @@ import { createContext, useState, ReactNode } from "react";
 import { StoreType } from "./types/StoreType";
 import { ExplorerType } from "@/types/ExplorerType";
 import { SelecaoTargetType } from "./types/SelecaoTargetType";
+import { TemaType } from "@/types/TemaType";
 
 interface StoreProviderProps {
     children: ReactNode;
@@ -16,6 +17,7 @@ export const StoreProvider = ({ children }: StoreProviderProps) => {
     const [projeto, setProjeto] = useState<ProjetoResponse>();
     const [explorer, setExplorer] = useState<ExplorerType>("domain");
     const [selecaoTarget, setSelecaoTarget] = useState<SelecaoTargetType>();
+    const [tema, setTema] = useState<TemaType>("sombrio");
 
     const storeValue: StoreType = {
         projeto: {
@@ -29,6 +31,10 @@ export const StoreProvider = ({ children }: StoreProviderProps) => {
         selecaoTarget: {
             get: () => selecaoTarget,
             set: setSelecaoTarget
+        },
+        tema: {
+            get: () => tema,
+            set: setTema
         }
     };
 

--- a/src/store/types/StoreType.ts
+++ b/src/store/types/StoreType.ts
@@ -2,9 +2,11 @@ import { ProjetoResponse } from "@/types/ProjetoResponse";
 import { GenericObjectType } from "./GenericObjectType";
 import { ExplorerType } from "@/types/ExplorerType";
 import { SelecaoTargetType } from "./SelecaoTargetType";
+import { TemaType } from "@/types/TemaType";
 
 export type StoreType = {
     projeto?: GenericObjectType<ProjetoResponse>;
     explorer?: GenericObjectType<ExplorerType>;
     selecaoTarget?: GenericObjectType<SelecaoTargetType>;
+    tema?: GenericObjectType<TemaType>;
 }

--- a/src/theme/globalStyles.ts
+++ b/src/theme/globalStyles.ts
@@ -1,15 +1,22 @@
-// Arquivo: src/theme/globalStyles.ts
 import { createGlobalStyle } from 'styled-components';
 import fonts from './fonts';
-import theme from './theme';
 
 const GlobalStyles = createGlobalStyle`
   ${fonts}
 
+  :root {
+    --background: ${({ theme }) => theme.colors.background};
+    --foreground: ${({ theme }) => theme.colors.foreground};
+    --border-color: ${({ theme }) => theme.colors.borderColor};
+    --panel-background: ${({ theme }) => theme.colors.panelBackground};
+    --accent-color: ${({ theme }) => theme.colors.accentColor};
+    --hover-background: ${({ theme }) => theme.colors.hoverBackground};
+  }
+
   body {
-    background: ${theme.colors.background};
-    color: ${theme.colors.foreground};
-    font-family: 'Rawline', sans-serif;
+    background: var(--background);
+    color: var(--foreground);
+    font-family: ${({ theme }) => theme.fonte};
     position: relative;
   }
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,5 +1,2 @@
-// Arquivo: src/theme/index.ts
-export { default as colors } from './colors';
-export { default as fonts } from './fonts';
-export { default as theme } from './theme';
+export { default as temas } from './temas';
 export { default as GlobalStyles } from './globalStyles';

--- a/src/theme/temas.ts
+++ b/src/theme/temas.ts
@@ -1,0 +1,85 @@
+import { TemaType } from '@/types/TemaType';
+
+type Tema = {
+  colors: {
+    background: string;
+    foreground: string;
+    borderColor: string;
+    panelBackground: string;
+    accentColor: string;
+    hoverBackground: string;
+  };
+  fonte: string;
+};
+
+const temas: Record<TemaType, Tema> = {
+  classico: {
+    colors: {
+      background: '#C0C0C0',
+      foreground: '#000000',
+      borderColor: '#808080',
+      panelBackground: '#FFFFFF',
+      accentColor: '#000080',
+      hoverBackground: '#B0B0B0',
+    },
+    fonte: 'Tahoma, sans-serif',
+  },
+  hacker: {
+    colors: {
+      background: '#000000',
+      foreground: '#00FF00',
+      borderColor: '#003300',
+      panelBackground: '#001900',
+      accentColor: '#00FF00',
+      hoverBackground: '#003300',
+    },
+    fonte: 'Courier New, monospace',
+  },
+  fofo: {
+    colors: {
+      background: '#FFE4F0',
+      foreground: '#FF69B4',
+      borderColor: '#FFB6C1',
+      panelBackground: '#FFFFFF',
+      accentColor: '#FF1493',
+      hoverBackground: '#FFD1DC',
+    },
+    fonte: 'Comic Sans MS, cursive',
+  },
+  elegante: {
+    colors: {
+      background: '#F5F5F0',
+      foreground: '#333333',
+      borderColor: '#D3D3C9',
+      panelBackground: '#FFFFFF',
+      accentColor: '#708090',
+      hoverBackground: '#E6E6E0',
+    },
+    fonte: 'Georgia, serif',
+  },
+  sombrio: {
+    colors: {
+      background: '#0D1117',
+      foreground: '#C9D1D9',
+      borderColor: '#30363D',
+      panelBackground: '#161B22',
+      accentColor: '#58A6FF',
+      hoverBackground: '#21262D',
+    },
+    fonte: 'Rawline, sans-serif',
+  },
+  clean: {
+    colors: {
+      background: '#FFFFFF',
+      foreground: '#000000',
+      borderColor: '#E0E0E0',
+      panelBackground: '#FAFAFA',
+      accentColor: '#3B82F6',
+      hoverBackground: '#F0F0F0',
+    },
+    fonte: 'Arial, sans-serif',
+  },
+};
+
+export default temas;
+export type { Tema };

--- a/src/types/TemaType.ts
+++ b/src/types/TemaType.ts
@@ -1,0 +1,1 @@
+export type TemaType = 'classico' | 'hacker' | 'fofo' | 'elegante' | 'sombrio' | 'clean';


### PR DESCRIPTION
## Sumário
- adiciona seis temas distintos
- permite escolha do tema na interface
- aplica cores via variáveis globais

## Testes
- `npm test` *(falhou: Missing script: "test")*
- `npm run lint` *(falhou: React Hook "useQuery" is called in function "getDominios" that is neither a React function component nor a custom React Hook function)*

------
https://chatgpt.com/codex/tasks/task_e_68966c03d6b08325a353686070a02994